### PR TITLE
Use saturn js-client

### DIFF
--- a/voyager.js
+++ b/voyager.js
@@ -76,7 +76,7 @@ export async function runBenchmark(saturn) {
 }
 
 async function sendSaturnRequest(saturn, cidPath) {
-    let { cidPath } = getWeightedRandomCid(cids)
+    cidPath = cidPath.replace('/ipfs/', '')
 
     const controller = new AbortController()
     const fetchOpts = {


### PR DESCRIPTION
# Goals

Use Saturn JS Client directly for voyager requests -- this adds a lot of additional functionality around using backup nodes.

# Implementation

Just moves code from ARC implementation, which enables us to remove a lot of code extras related to using this without the Saturn client.

# For Discussion

I intentionally did not put try catch logic around the client code cause I assume any uncaught exceptions should be escalated up to the top level activityState.Error() catch

Also, I wasn't sure how to test this -- should I run a Station node? How do I install the module manually?

Finally this is from a fork cause I don't have write access on the module.