### PR TITLE
fix: sleep for 100ms between benchmarks

### DIFF
--- a/voyager.js
+++ b/voyager.js
@@ -103,9 +103,8 @@ export async function runSaturnBenchmarkInterval() {
     } else {
         await runSaturnBenchmark()
     }
-    // console.log('Sleeping for 1s...')
-    // setTimeout(runSaturnBenchmarkInterval, 1000)
-    setTimeout(runSaturnBenchmarkInterval)
+    console.log('Sleeping for 100ms...')
+    setTimeout(runSaturnBenchmarkInterval, 100)
 }
 
 async function runSaturnBenchmark() {


### PR DESCRIPTION
- Check the assumption that there may be a bug in `setTimeout` implementation when it's called with no timeout value.

- Bring back the console log statement printed after a benchmark is finished but before we schedule the next one. This should give us visibility into the question whether Voyager gets stuck inside the benchmark code or in the main loop logic.

Links:
- https://filecoinproject.slack.com/archives/C03S6LXSRB8/p1712820650418649?thread_ts=1712766423.069179&cid=C03S6LXSRB8
